### PR TITLE
Fix: jsxSingleQuote false로 변경

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,7 +61,7 @@ export default [
           trailingComma: "all",
           arrowParens: "avoid",
           htmlWhitespaceSensitivity: "css",
-          jsxSingleQuote: true,
+          jsxSingleQuote: false,
         },
       ],
     },

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -4,6 +4,6 @@ module.exports = {
   trailingComma: "all",
   arrowParens: "avoid",
   htmlWhitespaceSensitivity: "css",
-  jsxSingleQuote: true,
+  jsxSingleQuote: false,
   plugins: [require("prettier-plugin-tailwindcss")],
 };


### PR DESCRIPTION
eslint, prettier config 파일에서 jsxSingleQuote false로 변경. (쌍따옴표만 사용하도록 변경함.)