### PR TITLE
Bugfix : korean ime enter issue

### DIFF
--- a/src/components/ChattingContainer.tsx
+++ b/src/components/ChattingContainer.tsx
@@ -75,7 +75,7 @@ function ChattingContainer({ nickname, profile, chatting, time, isMe }: any) {
             </div>
           </div>
           <div id="time" className="flex flex-col justify-end ml-3">
-            <p className="text-xs text-black">{convertTimeFormat()}</p>
+            <p className="text-slate-900 text-xs">{convertTimeFormat()}</p>
           </div>
         </div>
       )}

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -113,11 +113,12 @@ function Chat() {
     const sockJS = new SockJS("http://localhost:8080/stomp/chat");
     const client = Stomp.over(sockJS);
 
+    client.debug = () => {};
     client.heartbeat.outgoing = 0;
     client.heartbeat.incoming = 0;
 
     const onConnect = (frame: any) => {
-      console.log("Connected: ", frame);
+      console.log("Connected! ");
       subscribeToRoom(client, currentChannel.id);
       setStompClient(client);
     };
@@ -208,9 +209,11 @@ function Chat() {
 
   //키다운 핸들러(Enter 키 입력 시 메세지 전송)
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey && !isComposing && !!input.length) {
+    if (e.key === "Enter" && !e.shiftKey && !isComposing) {
+      if (input.trim()) {
+        sendMessage(input);
+      }
       e.preventDefault();
-      sendMessage(input);
     }
   };
 
@@ -291,20 +294,16 @@ function Chat() {
           className="px-2 overflow-y-auto"
           style={{ height: "calc(100vh - 172px)" }}
         >
-          {messages.map(
-            ({ id, senderUsername, senderNickname, content, regDate }) => (
-              <>
-                <ChattingContainer // TODO : 추후 response타입 변경에 따라 수정 필요.
-                  key={id}
-                  nickname={senderNickname}
-                  profile=""
-                  chatting={content}
-                  time={regDate}
-                  isMe={user.nickname === senderNickname}
-                />
-              </>
-            )
-          )}
+          {messages.map((message: Message, index) => (
+            <ChattingContainer
+              key={message.id}
+              nickname={message.senderNickname}
+              profile=""
+              chatting={message.content}
+              time={message.regDate}
+              isMe={user.nickname === message.senderNickname}
+            />
+          ))}
           <div ref={chatEndRef}></div>
         </div>
         <div className="w-full h-12 bg-white flex items-center justify-between mt-6 rounded-lg px-3">

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -208,7 +208,7 @@ function Chat() {
   };
 
   //키다운 핸들러(Enter 키 입력 시 메세지 전송)
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && !e.shiftKey && !isComposing) {
       if (input.trim()) {
         sendMessage(input);
@@ -218,7 +218,7 @@ function Chat() {
   };
 
   //입력값 변경 핸들러
-  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInput(e.target.value);
   };
 
@@ -229,7 +229,7 @@ function Chat() {
 
   //입력 구성 끝 핸들러
   const handleCompositionEnd = (
-    e: React.CompositionEvent<HTMLTextAreaElement>
+    e: React.CompositionEvent<HTMLInputElement>
   ) => {
     setIsComposing(false);
     setInput(e.currentTarget.value);
@@ -314,7 +314,7 @@ function Chat() {
             3. onCompositionStart : 사용자가 텍스트 입력을 시작할 때 발생. 주로 입력기가 활성화될 대 발생하며, 다국어 입력 시 조합 문자를 입력하기 시작할 때 트리거 됨.
             4. onCompositionEnd : 사용자가 텍스트 입력을 완료했을 때 발생. 조합 문자가 완성되거나 입력이 종료될 때 트리거 됨.
           */}
-          <textarea
+          <input
             className="w-full h-12 mx-3 focus:outline-none resize-none flex-1"
             style={{ resize: "none" }}
             placeholder="메세지를 입력해주세요."

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -146,7 +146,7 @@ function Chat() {
   const subscribeToRoom = (client: CompatClient, roomId: number) => {
     setMessages(() => []);
     getMessages(roomId).then((res: Message[]) => {
-      setMessages(res);
+      setMessages(() => res.reverse());
     });
 
     client.subscribe(`/topic/channel.${roomId}`, (message: any) => {
@@ -291,9 +291,8 @@ function Chat() {
           className="px-2 overflow-y-auto"
           style={{ height: "calc(100vh - 172px)" }}
         >
-          {messages
-            .reverse()
-            .map(({ id, senderUsername, senderNickname, content, regDate }) => (
+          {messages.map(
+            ({ id, senderUsername, senderNickname, content, regDate }) => (
               <>
                 <ChattingContainer // TODO : 추후 response타입 변경에 따라 수정 필요.
                   key={id}
@@ -304,7 +303,8 @@ function Chat() {
                   isMe={user.nickname === senderNickname}
                 />
               </>
-            ))}
+            )
+          )}
           <div ref={chatEndRef}></div>
         </div>
         <div className="w-full h-12 bg-white flex items-center justify-between mt-6 rounded-lg px-3">

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -291,8 +291,9 @@ function Chat() {
           className="px-2 overflow-y-auto"
           style={{ height: "calc(100vh - 172px)" }}
         >
-          {messages.map(
-            ({ id, senderUsername, senderNickname, content, regDate }) => (
+          {messages
+            .reverse()
+            .map(({ id, senderUsername, senderNickname, content, regDate }) => (
               <>
                 <ChattingContainer // TODO : 추후 response타입 변경에 따라 수정 필요.
                   key={id}
@@ -303,8 +304,7 @@ function Chat() {
                   isMe={user.nickname === senderNickname}
                 />
               </>
-            )
-          )}
+            ))}
           <div ref={chatEndRef}></div>
         </div>
         <div className="w-full h-12 bg-white flex items-center justify-between mt-6 rounded-lg px-3">


### PR DESCRIPTION
### Chat 관련 작업


**1. (주요 작업) 채팅 전송 시, message.trim()조건 추가**
문제 사항 : 한글 채팅 입력 후 Enter key 이벤트 발생 시, 채팅이 두번가는 버그 발생함. 엔터키를 눌렀을 때 발생하는 공백엔터까지 함께 포함되어 2번 보내짐.

**2. 채팅내역이 역순으로 보여지는 문제 발생하여 메세지 정렬 수정**

**3. stomp debug 제거** 
이유 : debug 정보가 너무 많이 나와서 콘솔창이 복잡해짐

**4. 스타일 수정**
- 메세지 전송 시간 색상 변경
- input 텍스트 정렬