### PR TITLE
Feat : infinite scroll

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,4 @@
 REACT_APP_API_URL = http://ec2-3-34-211-45.ap-northeast-2.compute.amazonaws.com:8080/api
-# REACT_APP_API_URL = http://localhost:8080/api
-REACT_APP_SOCKET_URL = ws://localhost:8080/stomp/chat
+REACT_APP_SOCKET_URL = http://ec2-3-34-211-45.ap-northeast-2.compute.amazonaws.com:8080/stomp/chat
 
 process.env.REACT_APP_SLACK_BOT_TOKEN

--- a/src/api/chat/ChatAPI.ts
+++ b/src/api/chat/ChatAPI.ts
@@ -1,10 +1,11 @@
-import { Message } from "../../types/chat";
+import { Chat } from "../../types/chat";
 import { Get } from "../util/apiUtils";
 
 const chatService = {
-  getMessages: async (channelId: number) => {
-    const response = await Get<Message[]>(`chat/${channelId}`);
-
+  getMessages: async (channelId: number, currentPage: number) => {
+    const response = await Get<Chat>(
+      `chat/${channelId}?currentPage=${currentPage}`
+    );
     return response.data.result;
   },
 

--- a/src/components/ChattingContainer.tsx
+++ b/src/components/ChattingContainer.tsx
@@ -37,7 +37,7 @@ function ChattingContainer({ nickname, profile, chatting, time, isMe }: any) {
       {isMe ? (
         <div id="me" className="flex justify-end my-5">
           <div id="time" className="flex flex-col justify-end mr-3">
-            <p className="text-xs text-black">{time}</p>
+            <p className="text-xs text-black">{convertTimeFormat()}</p>
           </div>
           <div className="mr-3">
             <div id="nickname" className="flex justify-end">

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -2,7 +2,14 @@ export interface Message {
   id: number | null;
   channelId: number;
   senderNickname: string;
-  senderUsername: string;
+  senderProfileImg: string;
+  workspaceJoinId: number;
   content: string;
   regDate: any;
+}
+
+export interface Chat {
+  messageResponseDtoList: Message[];
+  havePoint: boolean;
+  last: boolean;
 }


### PR DESCRIPTION
**1. env 파일 수정**

**2. `Get  api/chat/${channelId}?currentPage=${currentPage}` 리턴값에 아래 2가지 값 추가되었음**
- `havePoint`(안읽은 메세지 여부)
- `last`(마지막 페이지 여부)
```
export interface Message {
  id: number | null;
  channelId: number;
  senderNickname: string;
  senderProfileImg: string;
  workspaceJoinId: number;
  content: string;
  regDate: any;
}

export interface Chat {
  messageResponseDtoList: Message[];
  havePoint: boolean;
  last: boolean;
}
```

**3. 채팅 내역 무한스크롤 적용**
스크롤 이벤트로 구현하면 리플로우에 의해 좋지 않은 렌더링 성능과 상황에 따라 기대한 대로 동작하지 않을 수 있는 문제점이 있을 수 있어, 최근 주로 사용되는 Intersection Observer API를 통해 구현하였습니다. (참조 : https://developer.mozilla.org/ko/docs/Web/API/IntersectionObserver)
(동작 요약 : chatStartRef가 chatContainer와 겹쳐지는 영역이 생기게되면, get 요청)

[+ 역방향 무한스크롤]
css의 `flex-direction : column-reverse`를 사용하여 채팅컨테이너의 시작점과 끝점을 반대로 바꿔주었습니다.