### PR TITLE
Feat : focus unread message

### DIFF
--- a/src/api/chat/ChatAPI.ts
+++ b/src/api/chat/ChatAPI.ts
@@ -10,7 +10,7 @@ const chatService = {
   },
 
   searchLastReadMessageId: async (channelId: number) => {
-    const response = await Get(`chat/${channelId}/read/id`);
+    const response = await Get<string>(`chat/${channelId}/read/id`);
 
     return response.data.result;
   },

--- a/src/components/ChattingContainer.tsx
+++ b/src/components/ChattingContainer.tsx
@@ -2,7 +2,15 @@ import React, { useState, useRef, useEffect } from "react";
 import IconUser from "../assets/icon/icon_user_black.svg";
 
 //ChattingContainer 컴포넌트 정의
-function ChattingContainer({ nickname, profile, chatting, time, isMe }: any) {
+function ChattingContainer({
+  id,
+  nickname,
+  profile,
+  chatting,
+  time,
+  isMe,
+  isLastRead,
+}: any) {
   //chatNick 상태 변수와 setChatNick 함수 정의
   const [chatNick, setChatNick] = useState("");
 
@@ -35,7 +43,7 @@ function ChattingContainer({ nickname, profile, chatting, time, isMe }: any) {
   return (
     <>
       {isMe ? (
-        <div id="me" className="flex justify-end my-5">
+        <div id={id} className="flex justify-end my-5">
           <div id="time" className="flex flex-col justify-end mr-3">
             <p className="text-xs text-black">{convertTimeFormat()}</p>
           </div>
@@ -57,7 +65,7 @@ function ChattingContainer({ nickname, profile, chatting, time, isMe }: any) {
           />
         </div>
       ) : (
-        <div id="you" className="flex my-5">
+        <div id={id} className="flex my-5">
           <img
             id="profile"
             src={IconUser}
@@ -77,6 +85,16 @@ function ChattingContainer({ nickname, profile, chatting, time, isMe }: any) {
           <div id="time" className="flex flex-col justify-end ml-3">
             <p className="text-slate-900 text-xs">{convertTimeFormat()}</p>
           </div>
+        </div>
+      )}
+
+      {isLastRead && !isMe && (
+        <div className="flex items-center justify-center pt-3 pb-3">
+          <span className="grow h-[1px] bg-slate-400 m-2"></span>
+          <span className="bg-slate-700 text-white px-4 py-1 text-xs rounded">
+            여기까지 읽었습니다.
+          </span>
+          <span className="grow h-[1px] bg-slate-400 m-2"></span>
         </div>
       )}
     </>

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,5 +1,5 @@
 export interface Message {
-  id: number | null;
+  id: string | null;
   channelId: number;
   senderNickname: string;
   senderProfileImg: string;


### PR DESCRIPTION
**1. 마지막으로 읽은 메세지부터 보여주기**
- `isHavePoint = true`가 될때까지 GET `api/chat/{channelId}?currentPage={currentPage}` 수행
_(isHavePoint : 마지막 읽은 메세지가 현재 페이지에 있는지 확인)_
- 채널에 안읽은 메세지 쌓인 경우 마지막으로 읽었던 메세지의 ref를 찾아 scrollIntoView 적용


**2. '여기까지 읽었습니다' 문구 추가**
<img width="1011" alt="스크린샷 2024-10-23 오후 6 05 08" src="https://github.com/user-attachments/assets/61a23bc0-466a-41f1-9a21-29553ab45eb6">

```
// chattingContainer.tsx

{isLastRead && !isMe && (
        <div className="flex items-center justify-center pt-3 pb-3">
          <span className="grow h-[1px] bg-slate-400 m-2"></span>
          <span className="bg-slate-700 text-white px-4 py-1 text-xs rounded">
            여기까지 읽었습니다.
          </span>
          <span className="grow h-[1px] bg-slate-400 m-2"></span>
        </div>
      )}
```

**3. `isSentByMe` state 추가**
내가 보낸 메세지라면, 하단으로 자동 스크롤되도록 하기 위해