### PR TITLE
Feature : save channel id in session storage

### DIFF
--- a/src/api/util/apiUtils.ts
+++ b/src/api/util/apiUtils.ts
@@ -85,6 +85,7 @@ axiosInstance.interceptors.response.use(
         case 4057: // AUTH_FAIL_PASSWORD_MATCHING(BAD_REQUEST,4057,"비밀번호가 올바르지 않습니다.")
           sessionStorage.removeItem("accessToken");
           sessionStorage.removeItem("refreshToken");
+          sessionStorage.removeItem("currentChannelId");
           window.location.href = "/";
           break;
         default:

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -129,15 +129,6 @@ function Chat() {
     // 2. workspace의 채널들 리스트 GET -> 채널 데이터 바인딩
     getWorkspaceChannels(currentWorkspace.id).then((channels: Channel[]) => {
       if (channels) {
-        channels.forEach(
-          async (channel) =>
-            await getUnreadMessageCount(channel.id).then((count) => {
-              if (count) {
-                channel.unReadCount = count;
-              }
-            })
-        );
-
         setChannels(() => channels);
 
         const channelId = getChannelIdByStorage(channels);
@@ -334,7 +325,7 @@ function Chat() {
       // 선택한 채널의 '안읽은 메세지 개수' 초기화
       const modifiedChannels = channels?.map((channel) => {
         if (channel.id === selectedChannel.id) {
-          channel.unReadCount = 0;
+          channel.unreadCount = 0;
         }
         return channel;
       });
@@ -405,9 +396,9 @@ function Chat() {
                 onClick={() => handleChannelChange(channel)}
               >
                 <p className="text-sm font-bold text-white"># {channel.name}</p>
-                {channel.unReadCount ? (
+                {channel.unreadCount ? (
                   <p className="text-xs text-gray">
-                    {channel.unReadCount} new messages
+                    {channel.unreadCount} new messages
                   </p>
                 ) : (
                   <></>

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -139,10 +139,23 @@ function Chat() {
         );
 
         setChannels(() => channels);
-        setCurrentChannel(() => channels[0]);
+
+        const channelId = getChannelIdByStorage(channels);
+
+        channelId
+          ? setCurrentChannel(channelId)
+          : setCurrentChannel(channels[0]);
       }
     });
   }, [currentWorkspace.id, user.id]);
+
+  const getChannelIdByStorage = (channels: Channel[]) => {
+    const channelId = sessionStorage.getItem("currentChannelId");
+
+    if (channelId) {
+      return channels.find((channel) => channel.id === parseInt(channelId));
+    }
+  };
 
   useEffect(() => {
     if (!currentChannel) return;
@@ -304,6 +317,11 @@ function Chat() {
   };
 
   const handleChannelChange = (selectedChannel: Channel) => {
+    sessionStorage.setItem(
+      "currentChannelId",
+      JSON.stringify(selectedChannel.id)
+    );
+
     if (currentChannel) {
       if (currentChannel.id !== selectedChannel.id) {
         setPage(0);

--- a/src/types/workspace.d.ts
+++ b/src/types/workspace.d.ts
@@ -16,7 +16,7 @@ export interface Channel {
   lastModifiedDate: string;
   id: number;
   name: string;
-  unReadCount: number = 0; //0으로 초기화
+  unreadCount: number; //0으로 초기화
 }
 
 export interface RequestCreateWorkspaceParams {


### PR DESCRIPTION
**1. session storage -> channel id 저장**
새로고침 시, 채널이 유지되지않고 첫번째 채널로 초기화되어버리는 문제 발생.

**2. 리팩토링**
get api/channels의 리턴값에 채널별로 unreadCount값이 추가됨에 따라서, 채널별로 count api를 호출할 필요가 없어짐.
<img width="1058" alt="스크린샷 2024-10-23 오후 7 13 38" src="https://github.com/user-attachments/assets/5d00f072-1c60-4dfd-8b66-b5f7f2dc4bdf">
