### PR TITLE
add: deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to EC2 Instance 
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: docker build -t sh020119/project_frontend:latest .
+
+      - name: Push Docker image to Docker Hub
+        run: docker push sh020119/project_frontend:latest
+
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v0.1.5
+        with:
+          host: ${{ secrets.LIVE_SERVER_IP }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY }}
+          port: 22
+          script: |
+            docker stop frontend_container 
+            docker rm frontend_container
+            docker pull sh020119/project_frontend:latest
+            docker run -d --name frontend_container -p 3000:3000 sh020119/project_frontend:latest

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,17 @@
+# Step 1: Node 17 이미지를 사용해 리액트 애플리케이션 빌드
+FROM node:17 AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+RUN npm run build
+
+# Step 2: Nginx로 정적 파일 서빙
+FROM nginx:alpine
+COPY --from=builder /app/build /usr/share/nginx/html
+
+# Nginx 설정 파일 복사
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 3000
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,14 @@
+server {
+    listen 3000;
+    server_name localhost;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ /index.html;  # 모든 요청을 index.html로 리다이렉트
+    }
+
+    location ~ /\.ht {
+        deny all;  # .htaccess 파일 접근 차단
+    }
+}


### PR DESCRIPTION
깃허브의 워크플로우 관리나 도커를 이용하여 빌드, 배포 관리하는 방식은 프론트랑 백 가릴 것 없이 기본 소양으로 하는 느낌이어서 관련 내용에 대해 설명드리면 승현님께서 나중에 도움되실 것 같아서 적습니다

### 깃허브 워크플로우
워크플로우는 깃허브 액션 기능을 사용해서 특정 프로세스를 자동화하는 yaml파일입니다. 제가 이 pr에서 추가한 내용에서는 `.github/workflows/deploy.yml` 파일이 그 예시입니다.  깃허브 내에서의 코드 푸쉬나 머지, 풀 리퀘스트가 이벤트 트리거가 되어서 특정 작업을 수행합니다. 

`deploy.yml` 기능은 리액트 프로젝트를 빌드한 뒤, 도커 허브에 push 하고, aws ec2 컴퓨터에 접속하여 이 빌드한 이미지를 받아와 3000번 포트에 웹 서버를 재실행시키는 역할입니다. main 브랜치로 push 이벤트가 일어날 시 실행됩니다.
백엔드 레포에도 백엔드 빌드 배포 자동화를 위한 workflows yml 파일이 들어 있습니다. 이 워크플로우에서는 8080번 포트에 백엔드 api 서버를 실행 시키는 역할을 합니다. 
"빌드 배포 자동화" 로 검색하시면 관련 내용 찾아보실 수 있습니다!
참고로 이러한  워크플로우 처리들은 모두 깃허브 측에서 가상 리눅스 컴퓨터를 하나 할당해서 처리해줍니다.

### `deploy.yml` 의 프로세스
1. 레포에 있는 리액트 프로젝트를 도커파일을 이용하여 빌드(nginx와 같이 있음)  -> 도커 이미지(도커 이미지는 개발 환경과 프로젝트 파일 및 해당 파일의 실행 커맨드가 담긴 묶음이라고 생각하시면 됩니다.)  가 생성 
2. 도커 이미지를 도커 허브에 push함. (도커 허브는 깃허브 처럼 프로젝트를 push하고 pull 할 수 있는 버전 관리 사이트입니다.)
3. ec2 컴퓨터에 접속
4. 컴퓨터에서 도커허브에 올라간 이미지를 pull함
5. 해당 이미지를 `docker run` 으로 실행 시킴 -> 3000번 포트에 nginx 웹서버가 실행 됨

이렇게 자동화하는 까닭은, 만약 리액트 웹페이지가 배포 및 서비스 하고 있는 경우 버그 수정이나 업데이트 사항을 자동으로 배포서버에 반영할 수 있기 때문입니다. 저희는 개발 중에 프론트 웹서버를 배포 하고 있을 필요가 없어서 백엔드만 자동화를 만들어 놓았는데, 프로젝트가 거의 다 끝나서 완료전에 이를 반영하고 싶어서 pr을 올립니다.

### 도커
도커는 개발 환경과 어플리케이션 들을 하나의 묶음으로 컨테이너화하여 개발과 배포 등을 쉽게 해주는 기술입니다. 이 레포의 도커 파일에는 nginx 웹서버 배포에 필요한 명령어들이 작성되어 있습니다

### nginx
웹서버 배포 프로그램 중 하나입니다. 기본 셋팅은 80번 포트에 접속하면 지정된 index.html 을 제공해주는 역할을 하는데, nginx.conf 를 이용해서 셋팅을 수정할 수 있습니다. nginx 는 컴퓨터에 직접 설치해서 실행할 수 있는데, 저는 도커허브에서 nginx 이미지를 받아와서 간편하게 사용하는 방식을 이용했습니다.